### PR TITLE
Update pytorch version in USAGE.md

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -16,7 +16,7 @@ pytorch, yaml, tensorboard (from https://github.com/dmlc/tensorboard), and tenso
 
 The code base was developed using Anaconda with the following packages.
 ```
-conda install pytorch=0.3 torchvision cuda80 -c pytorch;
+conda install pytorch=0.4 torchvision cuda80 -c pytorch;
 conda install -y -c anaconda pip;
 conda install -y -c anaconda pyyaml;
 pip install tensorboard tensorboardX;


### PR DESCRIPTION
Running the examples with pytorch 0.3 causes an error:

```
(img2img) paperspace@psgg6az8h:~/img2img/MUNIT$ python test.py --config configs/edges2handbags_folder.yaml --input inputs/edge.jpg --output_folder outputs --checkpoint models/edges2handbags.pt --a2b 1
Traceback (most recent call last):
  File "test.py", line 48, in <module>
    trainer = MUNIT_Trainer(config)
  File "/home/paperspace/img2img/MUNIT/trainer.py", line 17, in __init__
    self.gen_a = AdaINGen(hyperparameters['input_dim_a'], hyperparameters['gen'])  # auto-encoder for domain a
  File "/home/paperspace/img2img/MUNIT/networks.py", line 105, in __init__
    self.enc_content = ContentEncoder(n_downsample, n_res, input_dim, dim, 'in', activ, pad_type=pad_type)
  File "/home/paperspace/img2img/MUNIT/networks.py", line 210, in __init__
    self.model += [Conv2dBlock(input_dim, dim, 7, 1, 3, norm=norm, activation=activ, pad_type=pad_type)]
  File "/home/paperspace/img2img/MUNIT/networks.py", line 308, in __init__
    self.norm = nn.InstanceNorm2d(norm_dim, track_running_stats=True)
TypeError: __init__() got an unexpected keyword argument 'track_running_stats'
```

`track_running_stats` isn't defined until pytorch > 0.3.1.
[pytorch:nn.modules.instancenorm@0.3.1](https://github.com/pytorch/pytorch/blob/v0.3.1/torch/nn/modules/instancenorm.py)
[pytorch:nn.modules.instancenorm@0.4.0](https://github.com/pytorch/pytorch/blob/v0.4.0/torch/nn/modules/instancenorm.py)